### PR TITLE
Fix FileDataError exception

### DIFF
--- a/fitz_validate.py
+++ b/fitz_validate.py
@@ -9,7 +9,7 @@ import os
 def read_pdf(path: str) -> str:
     try:
         doc = fitz.open(path)
-    except fitz.fitz.FileDataError:
+    except fitz.FileDataError:
         print(f"Error: Unable to open or read the document '{path}'. It may be broken.")
         quarantine_file(path)
         return ""


### PR DESCRIPTION
## Summary
- fix deprecated fitz FileDataError path for PDF validation

## Testing
- `python -m py_compile fitz_validate.py`

------
https://chatgpt.com/codex/tasks/task_e_686d2699bb1483269c0417b514bfeb7b