### PR TITLE
Add argparse to forecast scripts

### DIFF
--- a/FY-forecast-v2.py
+++ b/FY-forecast-v2.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 import numpy as np
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
@@ -5,9 +6,14 @@ import matplotlib.pyplot as plt
 from sklearn.metrics import mean_squared_error
 import os
 
+parser = argparse.ArgumentParser(description="Generate FY26 forecasts")
+parser.add_argument("--data", required=True, help="Path to input Excel file")
+parser.add_argument("--output", required=True, help="Path for the output Excel file")
+args = parser.parse_args()
+
 # Load the Excel file with MultiIndex columns
 df = pd.read_excel(
-    r'C:\Users\...\GitHub\ETL-tools\data.xlsx',
+    args.data,
     header=[0, 1]
 )
 
@@ -102,7 +108,7 @@ forecasts.columns = [f'FY26_{month}' for month in forecast_months]
 #forecasts[['FY25_Dec', 'FY25_Jan', 'FY25_Mar']] *= 0.5  # 50% reduction
 
 # Save the forecasted data to a new Excel file
-output_file = r'C:\Users\...\GitHub\ETL-tools\FY25_Forecasts_from_Jan.xlsx'
+output_file = args.output
 forecasts.to_excel(output_file, sheet_name='FY26 Forecasts')
 
 print(f"Forecasts successfully saved to {output_file}")

--- a/FY-forecast-v3.py
+++ b/FY-forecast-v3.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 import numpy as np
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
@@ -5,10 +6,15 @@ import matplotlib.pyplot as plt
 from sklearn.metrics import mean_squared_error
 import os
 
+parser = argparse.ArgumentParser(description="Generate FY26 forecasts with MSE")
+parser.add_argument("--data", required=True, help="Path to input Excel file")
+parser.add_argument("--output", required=True, help="Path for the output Excel file")
+args = parser.parse_args()
+
 
 # Load the Excel file with MultiIndex columns
 df = pd.read_excel(
-    r'C:\Users\...\GitHub\ETL-tools\data.xlsx',
+    args.data,
     header=[0, 1]
 )
 
@@ -109,7 +115,7 @@ forecasts = forecasts.T
 forecast_months = ['Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec','Jan','Feb','Mar']
 forecasts.columns = [f'FY26_{m}' for m in forecast_months]
 
-output_file = r'C:\Users\...\GitHub\ETL-tools\FY25_Forecasts_from_Jan.xlsx'
+output_file = args.output
 forecasts.to_excel(output_file, sheet_name='FY26 Forecasts')
 
 for cluster, mse_val in mse_dict.items():

--- a/FY-forecast.py
+++ b/FY-forecast.py
@@ -1,11 +1,17 @@
+import argparse
 import pandas as pd
 import numpy as np
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
 import matplotlib.pyplot as plt
 from sklearn.metrics import mean_squared_error
 
+parser = argparse.ArgumentParser(description="Generate FY25 forecasts")
+parser.add_argument("--data", required=True, help="Path to input Excel file")
+parser.add_argument("--output", required=True, help="Path for the output Excel file")
+args = parser.parse_args()
+
 # Load the Excel file with MultiIndex columns
-df = pd.read_excel('C:\\Users\\...\\GitHub\\ETL-tools\\data.xlsx', header=[0, 1])
+df = pd.read_excel(args.data, header=[0, 1])
 
 # Drop any unnecessary unnamed columns
 df.drop(columns=[('Unnamed: 0_level_0', 'Unnamed: 0_level_1')], inplace=True)
@@ -75,7 +81,7 @@ forecasts.columns = [f'FY25_{month}' for month in forecast_months]
 forecasts[['FY25_Sep', 'FY25_Oct', 'FY25_Nov']] *= 0.4  # 60% reduction
 
 # Save the forecasted data to a new Excel file
-output_file = 'C:\\Users\\...\\GitHub\\ETL-tools\\FY25_Forecasts_from_July.xlsx'
+output_file = args.output
 forecasts.to_excel(output_file, sheet_name='FY25 Forecasts')
 
 print(f"Forecasts successfully saved to {output_file}")

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Created this new repo to store the scripts seperately.
 [jira_dl.py](./docs/jira_dl.md)
 
 [salesforce_dl.py](./docs/salesforce_dl.md)
+[forecast scripts](./docs/forecast_scripts.md)
 
 # privateGPT - primordial
 

--- a/TS-Forecast.py
+++ b/TS-Forecast.py
@@ -1,10 +1,15 @@
+import argparse
 import pandas as pd
 from sklearn.linear_model import LinearRegression
 import numpy as np
 
+parser = argparse.ArgumentParser(description="Predict future timesheet totals")
+parser.add_argument("--data", required=True, help="Path to the timesheet Excel file")
+parser.add_argument("--output", required=True, help="Path for the output Excel file")
+args = parser.parse_args()
+
 # Load the timesheet data
-file_path = r'C:\Users\86011919\...\GitHub\ETL-tools\\timesheets.xlsx'
-df = pd.read_excel(file_path)
+df = pd.read_excel(args.data)
 
 # Convert the 'Row Labels' column to datetime by extracting the start date of the range
 df['Row Labels'] = pd.to_datetime(df['Row Labels'].apply(lambda x: x.split(' - ')[0]), format='%d/%m/%Y')
@@ -48,7 +53,7 @@ predicted_df = pd.DataFrame(predictions, index=future_dates)
 predicted_df['Grand Total'] = predicted_df.sum(axis=1)
 
 # Save the predictions to a new Excel file
-output_file = r'C:\Users\86011919\...\GitHub\ETL-tools\\predicted_timesheets.xlsx'
+output_file = args.output
 predicted_df.to_excel(output_file)
 
 print(f"Predictions saved to {output_file}")

--- a/docs/forecast_scripts.md
+++ b/docs/forecast_scripts.md
@@ -1,0 +1,13 @@
+# Forecast Scripts
+
+These forecasting utilities read Excel workbooks and output new workbooks with predicted values.
+
+## Usage
+
+All scripts accept the same two command line options:
+
+```bash
+python FY-forecast.py --data data.xlsx --output forecasts.xlsx
+```
+
+Replace the script name with `FY-forecast-v2.py`, `FY-forecast-v3.py` or `TS-Forecast.py` as needed.  `--data` specifies the path to the input Excel file and `--output` is the file that will be written.


### PR DESCRIPTION
## Summary
- parameterize input/output paths in forecasting scripts
- document CLI usage for forecasts

## Testing
- `python -m py_compile FY-forecast.py FY-forecast-v2.py FY-forecast-v3.py TS-Forecast.py`

------
https://chatgpt.com/codex/tasks/task_e_686d283acd188326a23d88bd6379209e