### PR TITLE
Improve README for configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,44 @@
 # ETL Tools
 
-Initially created this repo with some scripts for bulk download of Confluence, Jira and Salesforce docs, and validate/quarantine some buggy PDFs that didn't work and caused privateGPT to throw an error.
+This repository contains various scripts for data extraction and processing. The scripts are designed for internal automation tasks such as downloading content from Confluence, Jira, and Salesforce, creating opportunity folders, validating PDF files, and generating forecasts.
 
-Created this new repo to store the scripts seperately.
+## Configuration
 
-# Download Script How 2's:
+Before running any script, copy the default configuration file and fill in your credentials:
 
-[confluence_dl.py](./docs/confluence_dl.md)
+```bash
+cp config_default.yaml config.yaml
+```
 
-[jira_dl.py](./docs/jira_dl.md)
+Edit `config.yaml` and replace the placeholder values (`your_username`, `your_password`, etc.) with your real credentials for Jira, Confluence and Salesforce.
 
-[salesforce_dl.py](./docs/salesforce_dl.md)
+## Available Scripts
 
-# privateGPT - primordial
+| Script | Description |
+|-------|-------------|
+| `confluence_dl.py` | Download Confluence pages as PDFs. See [docs/confluence_dl.md](docs/confluence_dl.md) for details. |
+| `jira_dl.py` | Download Jira tickets as HTML files. See [docs/jira_dl.md](docs/jira_dl.md). |
+| `salesforce_dl.py` | Export Salesforce Knowledge articles to `knowledge_articles.json`. See [docs/salesforce_dl.md](docs/salesforce_dl.md). |
+| `opp_script.py` | Create opportunity folders from an Excel sheet. See [docs/opp_script.md](docs/opp_script.md). |
+| `fitz_validate.py` | Validate PDFs using PyMuPDF and move unreadable files to a `quarantine/` folder. |
+| `docx2pdf.py` | Convert `.docx` files to PDF. |
+| `xl_refresh.py` | Refresh Dynamics 365 connections in an Excel workbook. |
+| `FY-forecast*.py` | Forecast FY data from historical Excel data using Holt-Winters models. |
+| `TS-Forecast.py` | Forecast timesheet hours using linear regression. |
 
-In order to run PrivateGPT on my M2 mac I needed to uninstall and reinstall pymupdf to the latest version as the version PrivateGPT used contains a bug that was compiled with the wrong architecture.
+## Running a Script
 
-`pip3 install --upgrade --force-reinstall pymupdf`
+All scripts are standard Python files and can be executed with:
 
-To ingest HTML you need to update nltk, the easiest way is this:
+```bash
+python <script_name.py> [arguments]
+```
 
-`python3 -m nltk.downloader all`
-https://github.com/imartinez/privateGPT/issues/345
+Refer to the documentation in the `docs/` directory for script-specific options and examples. For example, to download a Jira ticket you can run:
+
+```bash
+python jira_dl.py --issue TICKET-123
+```
+
+For more complex workflows, consult the guide corresponding to the script you are using.
+


### PR DESCRIPTION
## Summary
- expand README with script descriptions and docs references
- explain copying `config_default.yaml` to `config.yaml`
- add basic usage instructions for running scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2b4758d083269ea9acb0f1cff16c